### PR TITLE
Update request to a version after hawk was removed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/brightcove/stubby-request#readme",
   "dependencies": {
     "chai": "~3.5.0",
-    "request": "~2.79.0"
+    "request": "~2.88.0"
   },
   "devDependencies": {
     "grunt": "~1.0.1",


### PR DESCRIPTION
This uses a newer version of request that no longer has a dependency on hawk.